### PR TITLE
new action: require-semver-guidance-label

### DIFF
--- a/.github/workflows/require-semver-guidance-label.yml
+++ b/.github/workflows/require-semver-guidance-label.yml
@@ -1,0 +1,87 @@
+on:
+  pull_request:
+    paths:
+      - require-semver-guidance-label/*
+      - .github/workflow/require-semver-guidance-label.yml
+    types: [opened, labeled, unlabeled, edited, reopened, synchronize]
+
+  push:
+    branches:
+      - main
+      - dry-run
+    paths:
+      - require-semver-guidance-label/*
+
+env:
+  action_name: require-semver-guidance-label
+
+jobs:
+  validate-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      # For pull requests, we run the docker image, instead of
+      # an already-merged code.
+      - run: |
+          docker build -t ${action_name} ./${action_name}
+          docker run ${action_name} \
+            --github-repository ${{ github.repository }} \
+            --github-ref ${{ github.ref }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+        id: run-action
+
+  release-dry-run:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      # Uses the version that was just released, to validate the
+      # actual action setup.
+      - uses: uwit-iam/actions/require-semver-guidance-label@dry-run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_PR_NUMBER: 2  # An old PR that has guidance set on it for testing
+        id: semver
+
+      # Releases the new actions version based on the guidance provided
+      # by the release's own pull request.
+      - name: Bump uwit-iam/actions release version
+        uses: hennejg/github-tag-action@v4.3.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          tag_prefix: ''
+          default_bump: ${{ steps.semver.outputs.guidance }}
+          dry_run: true
+          create_annotated_tag: true
+
+  validate-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        id: pr
+
+      # Uses the version that was just released, to validate the
+      # actual action setup.
+      - uses: uwit-iam/actions/require-semver-guidance-label@main
+        env:
+          GITHUB_PR_NUMBER: ${{ steps.pr.outputs.number }}
+        id: semver
+
+      # Releases the new actions version based on the guidance provided
+      # by the release's own pull request.
+      - name: Bump uwit-iam/actions release version
+        uses: hennejg/github-tag-action@v4.3.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+          tag_prefix: ''
+          default_bump: ${{ steps.semver.outputs.guidance }}
+          dry_run: false
+          create_annotated_tag: true

--- a/require-semver-guidance-label/Dockerfile
+++ b/require-semver-guidance-label/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/uwit-iam/poetry:latest
+WORKDIR /
+RUN pip install pygithub
+COPY require_semver_guidance_label.py ./
+ENTRYPOINT ["/require_semver_guidance_label.py"]

--- a/require-semver-guidance-label/README.md
+++ b/require-semver-guidance-label/README.md
@@ -1,0 +1,89 @@
+# uwit-iam/actions/require-semver-guidance-label
+
+This action requires that a pull request have a 
+label in the format off `semver-guidance:foo`, where `foo`
+is either an explicit version (e.g., `1.2.3`) or a 
+guidance directive such as `prerelease`, `patch`, `minor`, `major`. 
+
+If you include this action in your pull request workflow, your validations will fail until 
+an authorized user (or some automated task) sets version guidance for a pull request as part of the change review process.
+
+The intended use is that you can require a pull request to have one of these 
+labels before it can be approved, so that your CICD workflow can automatically
+set the version for the change when it is merged into your default branch.
+
+The label can either be set by some automated process, or by
+a reviewer with requisite access to apply the label.
+
+**Inputs:**
+- [github-token](#github-token)*
+
+**Outputs:**
+- [pr-number](#pr-number)
+- [guidance](#guidance)
+
+## Example Use
+
+
+**Basic use:**
+```yaml
+- uses: uwit-iam/actions/require-semver-guidance-label@1.0.0
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Full example:**
+
+This example shows how you might use a tool like poetry 
+to update the version of a pull request branch.
+
+```yaml
+# ./github/workflows/bump-version.yml
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uwit-iam/actions/require-semver-guidance-label@1.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        id: semver
+      # Everything below shows how you might use this output. 
+      - uses: abatilo/actions-poetry@v2.1.0
+      - run: |
+          poetry version ${{ steps.semver.outputs.guidance }}
+          version=$(poetry version -s)
+          echo ::set-output name=new-version::$version
+        id: poetry
+      - run: |
+          docker build -t $image
+          docker push $image
+        env:
+          image: ghcr.io/my-project/my-repo:${{ steps.poetry.outputs.new-version }}
+      - uses: EndBug/add-and-commit@v7.2.1
+        with:
+          add: pyproject.toml
+          default_author: github_actions
+          signoff: true
+          message: "[auto-commit] Update app version to ${{ steps.poetry.outputs.new-version }}"
+```
+
+## Inputs
+
+### `github-token`*
+
+**REQUIRED**. The github token for the current workflow run.
+
+## Outputs
+
+### `pr-number`
+
+The PR number whose labels were validated.
+
+### `guidance`
+
+The guidance string derived from the label.

--- a/require-semver-guidance-label/action.yml
+++ b/require-semver-guidance-label/action.yml
@@ -1,0 +1,24 @@
+name: Ensure a pull request has a "semver-guidance" label.
+author: '@tomthorogood'
+description: >
+  Requires that a pull request have a label in the format
+  of 'semver-guidance:foo', where 'foo' can be an explicit
+  version (e.g., 1.2.3) or a guidance level, e.g.:
+  prerelease, patch, minor, major.
+inputs:
+  github-token:
+    description: "The github token."
+    required: true
+
+outputs:
+  pr-number:
+    description: The PR number associated with this change
+  guidance:
+    description: The version guidance derived from the PR labels.
+
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - '--github-token'
+    - ${{ inputs.github-token }}

--- a/require-semver-guidance-label/require_semver_guidance_label.py
+++ b/require-semver-guidance-label/require_semver_guidance_label.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import re
+from typing import Any
+
+from github import Github
+from argparse import ArgumentParser
+import os
+
+
+def get_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        'Verify labels attached to a pull request.'
+    )
+    parser.add_argument('--github-ref', default=os.environ.get('GITHUB_REF'))
+    parser.add_argument('--github-token', default=os.environ.get('GITHUB_TOKEN'))
+    parser.add_argument('--github-repository', default=os.environ.get('GITHUB_REPOSITORY'))
+    parser.add_argument('--pr-number', default=os.environ.get('GITHUB_PR_NUMBER'))
+    return parser
+
+
+def get_pr_number(github_ref: str) -> int:
+    try:
+        return int(re.search('refs/pull/([0-9]+)/merge', github_ref).group(1))
+    except Exception:
+        raise ValueError(
+            f'Could not determine pull request number from GITHUB_REF "{github_ref}"'
+        )
+
+
+def set_ci_output(key: str, val: Any):
+    print(f'::set-output name={key}::{val}')
+
+
+if __name__ == "__main__":
+    args = get_parser().parse_args()
+    repo = Github(args.github_token).get_repo(args.github_repository)
+    if getattr(args, 'pr_number', None):
+        pr_number = int(args.pr_number)
+    else:
+        pr_number = get_pr_number(args.github_ref)
+
+    guidance = [
+        label.name.split(':')[-1] for label in repo.get_pull(pr_number).labels
+        if label.name.startswith('semver-guidance:')
+    ]
+    if len(guidance) > 1:
+        raise ValueError('Too many guidance labels applied! '
+                         'Please remove extraneous "semver-guidance" labels '
+                         f'from PR#{pr_number}')
+    elif not guidance:
+        raise ValueError(
+            'No guidance labels provided. Please add a label to '
+            f'pull request #{pr_number} in the format of '
+            f"'semver-guidance:foo' where 'foo' is one of "
+            "prerelease, patch, minor, major, or some explicit "
+            "version string."
+        )
+
+    set_ci_output('pr-number', pr_number)
+    set_ci_output('guidance', guidance[0])


### PR DESCRIPTION
Adds a new action to the collection. This action makes it possible to require that pull requests have an assigned version guidance string before it is allowed to be merged.

I plan to use this in the new directory CI/CD to enforce an explicit version with each merge to our default branch. This will currently be a human decision on a PR-by-PR basis for subscribing repositories, but could be automated to some degree if necessary.

The new workflow added here will use the action to automatically create a release of this repository any time _this particular_ action is updated, which saves me a step. In the future, once I'm sure it works as intended, I'll update to use this any time any new stuff is merged into this repository's main branch.