### PR TITLE
[IAM-263] Support pruning GCR repositories using a shared action. Add manual workflow for on-demand pruning.

### DIFF
--- a/.github/workflows/prune-gcr.yml
+++ b/.github/workflows/prune-gcr.yml
@@ -1,0 +1,32 @@
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        required: true
+        description: >
+          The full gcr.io path to your repository,
+          e.g., gcr.io/your-gcloud-project/your-app.
+          The default will fail.
+        default: gcr.io/uwit-mci-iam/your-app-name
+      time-ago:
+        required: true
+        default: '2 years ago'
+        description: >
+          Images before this date will be deleted. Use a semantic argument
+          like "yesterday" or "1 year ago". The default is "2 years ago".
+
+jobs:
+  prune-gcr:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ inputs.repository }}
+      cancel-in-progress: true
+    timeout-minutes: 360
+    steps:
+      - uses: UWIT-IAM/actions/configure-gcloud-docker@0.1
+        with:
+          gcloud-token: ${{ secrets.GCR_TOKEN }}
+      - uses: UWIT-IAM/actions/prune-gcr-images@0.1
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          time-ago: ${{ github.event.inputs.time-ago }}

--- a/prune-gcr-images/action.yml
+++ b/prune-gcr-images/action.yml
@@ -1,0 +1,27 @@
+
+inputs:
+  time-ago:
+    default: '2 years ago'
+    description: >
+      Provide a semantic argument for how old images
+      can be before they are pruned. The default is `2 years ago`.
+      The argument must be parseable by the unix `date` command.
+  repository:
+    description:
+      Your gcr.io repository; your input must include the full
+      address, e.g., 'gcr.io/your-gcloud-project-name/your-repo'.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: get-prune-date
+      run: |
+        target=$(date -d "${{ inputs.time-ago }}" +"%Y-%m-%d")
+        echo ::set-output name=date::${target}
+      shell: bash
+    - id: prune-images
+      env:
+        cutoff_date: ${{ steps.get-prune-data.outputs.date }}
+        repo: ${{ inputs.repository }}
+      run: ./prune-gcr.sh ${repo} ${cutoff_date}

--- a/prune-gcr-images/prune-gcr.sh
+++ b/prune-gcr-images/prune-gcr.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright © 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ "$#" -ne 2 || "${1}" == '-h' || "${1}" == '--help' ]]; then
+  cat >&2 <<"EOF"
+prune-gcr.sh cleans up tagged or untagged images pushed before specified date
+for a given repository (an image name without a tag/digest).
+
+USAGE:
+  prune-gcr.sh REPOSITORY DATE
+
+EXAMPLE
+  prune-gcr.sh gcr.io/ahmet/my-app 2017-04-01
+
+  would clean up everything under the gcr.io/ahmet/my-app repository
+  pushed before 2017-04-01.
+EOF
+  exit 1
+elif [[ "${#2}" -ne 10 ]]; then
+  echo "wrong DATE format; use YYYY-MM-DD." >&2
+  exit 1
+fi
+
+main(){
+  local C=0
+  IMAGE="${1}"
+  DATE="${2}"
+  for digest in $(gcloud container images list-tags ${IMAGE} --limit=999999 --sort-by=TIMESTAMP \
+    --filter="timestamp.datetime < '${DATE}'" --format='get(digest)'); do
+    (
+      set -x
+      gcloud container images delete -q --force-delete-tags "${IMAGE}@${digest}"
+    )
+    let C=C+1
+  done
+  echo "Deleted ${C} images in ${IMAGE}." >&2
+}
+
+main "${1}" "${2}"


### PR DESCRIPTION
The pruning script was sourced from github and I tested it manually. I can't test the workflow/action until this is merged in.