### PR TITLE
[IAM-263] Only delete images if a minimum number of images are present 

### DIFF
--- a/prune-gcr-images/action.yml
+++ b/prune-gcr-images/action.yml
@@ -11,6 +11,11 @@ inputs:
       Your gcr.io repository; your input must include the full
       address, e.g., 'gcr.io/your-gcloud-project-name/your-repo'.
     required: true
+  minimum-images:
+    description: >
+      The number of images you want to keep, even if they are older than
+      the "time ago" argument. The default is 10.
+    default: 10
 
 runs:
   using: composite
@@ -21,8 +26,9 @@ runs:
         echo ::set-output name=date::${target}
       shell: bash
     - id: prune-images
-      env:
-        cutoff_date: ${{ steps.get-prune-date.outputs.date }}
-        repo: ${{ inputs.repository }}
-      run: ${{ github.action_path }}/prune-gcr.sh ${{ env.repo }} ${{ env.cutoff_date }}
+      run: |
+        ${{ github.action_path }}/prune-gcr.sh \
+          -m ${{ inputs.minimum-images }} \
+          -r ${{ inputs.repository }} \
+          -d ${{ steps.get-prune-date.outputs.date }}
       shell: bash


### PR DESCRIPTION
This change protects a repository from having its most recent X image digests deleted; X defaults to 10, but can be configured by callers.

- Updates argument parsing to match others in our ecosystem and be easier to extend
- Considers only unique digests (each of which may have multiple tags) when determining what can be deleted; this way, reference tags aren't deleted in lieu of their digests, which prevents us from removing all references to a digest we want to keep.