### PR TITLE
[NETID-1661] The UWIT-IAM action/workflow "update-pr-branch-version@0.1" has a broken poetry install reference

### DIFF
--- a/update-pr-branch-version/action.yml
+++ b/update-pr-branch-version/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Python Poetry Action
-      uses: abatilo/actions-poetry@v2.1.0
+      uses: abatilo/actions-poetry@v2.1.6
 
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Change Description:
When pushing a commit to the identity.uw repo, a few actions/workflows are called, one of them being "Pull request validation", which in turn calls uwit-iam/actions/update-pr-branch-version@0.1

In this we reference "abatilo/actions-poetry@v2.1.0". The 2.1.0 version of that GH action references poetry 1.1.11. which now breaks the build of identity.uw. Poetry 1.1.15 does not. abatilo/actions-poetry@v2.1.6 contains 1.1.15.

Update UWIT-IAM/actions/update-pr-branch-version/action.yml to this affect.

**Another JIRA will be created to bring the functionality of abatilo/actions-poetry in house instead of depending on this 3rd party.**

For reference about the need for this:
https://github.com/python-poetry/poetry/issues/6300
dependency
https://github.com/abatilo/actions-poetry

Closes Jira(s):
[NETID-1661](https://jira.cac.washington.edu/browse/NETID-1661)