### PR TITLE
[GH-495] Update finalize-slack-notification-canvas use of setup-gcloud version

### DIFF
--- a/finalize-slack-notification-canvas/action.yml
+++ b/finalize-slack-notification-canvas/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: google-github-actions/setup-gcloud@v0.2.1
+    - uses: google-github-actions/setup-gcloud@v1.0.1
       with:
         service_account_key: "${{ inputs.gcloud-token || env.GCLOUD_TOKEN }}"
         export_default_credentials: true


### PR DESCRIPTION
Closes Identity.UW's [GH-495]( https://github.com/UWIT-IAM/identity-uw/issues/495) See detail there.
Once this is merged in, this actions repo will need a release and [this line](https://github.com/UWIT-IAM/identity-uw/blob/develop/.github/workflows/deploy-from-ui.yml#L211) in identity will need to be updated to the chosen actions release version.  Aka "this line" then changes from `uses: UWIT-IAM/actions/finalize-slack-notification-canvas@0.1` to `uses: UWIT-IAM/actions/finalize-slack-notification-canvas@<release tag>`