### PR TITLE
[GH-496] Update setup-slack-notification-canvas use of setup-gcloud version

### DIFF
--- a/set-up-slack-notification-canvas/action.yml
+++ b/set-up-slack-notification-canvas/action.yml
@@ -19,7 +19,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: google-github-actions/setup-gcloud@v0.2.1
+    - uses: google-github-actions/setup-gcloud@v1.0.1
       with:
         service_account_key: "${{ inputs.gcloud-token || env.GCLOUD_TOKEN }}"
         export_default_credentials: true


### PR DESCRIPTION
Similar to previous PR.
Closes Identity.UW's https://github.com/UWIT-IAM/identity-uw/issues/496 See detail there.
Once this is merged in, I'll edit the actions 0.1.18 a release and [this line](https://github.com/UWIT-IAM/identity-uw/blob/develop/.github/workflows/deploy-from-ui.yml#L109) in identity will need to be updated to the chosen actions release version. Aka "this line" then changes from uses: UWIT-IAM/actions/set-up-slack-notification-canvas@0.1 to uses: UWIT-IAM/actions/set-up-slack-notification-canvas@0.1@<release tag>