### PR TITLE
Update set_ci_output syntax to match new paradigm

### DIFF
--- a/require-semver-guidance-label/require_semver_guidance_label.py
+++ b/require-semver-guidance-label/require_semver_guidance_label.py
@@ -29,7 +29,7 @@ def get_pr_number(github_ref: str) -> int:
 
 
 def set_ci_output(key: str, val: Any):
-    print(f'::set-output name={key}::{val}')
+    print(f'"{key}={val}" >> $GITHUB_OUTPUT')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

BEFORE: https://github.com/UWIT-IAM/netid_arrest/actions/runs/7804631985

![image](https://github.com/UWIT-IAM/actions/assets/26555712/1186dc75-2505-41e7-bd35-e3e0cc18a71e)


AFTER:  https://github.com/UWIT-IAM/netid_arrest/actions/runs/7804885952

No warning annotations for the "update-pr-branch-version" step

Note: neither linked workflow fully succeeds. That isn't related to this PR - this is just me doing a side-quest to fix deprecated things