### PR TITLE
Write to GITHUB_OUTPUT file

### DIFF
--- a/.github/workflows/require-semver-guidance-label.yml
+++ b/.github/workflows/require-semver-guidance-label.yml
@@ -28,8 +28,9 @@ jobs:
       # an already-merged code.
       - run: |
           docker build -t ${action_name} ./${action_name}
-          docker run ${action_name} \
+          docker run \
             --env GITHUB_OUTPUT=/dev/null \
+            ${action_name} \
             --github-repository ${{ github.repository }} \
             --github-ref ${{ github.ref }} \
             --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/require-semver-guidance-label.yml
+++ b/.github/workflows/require-semver-guidance-label.yml
@@ -29,6 +29,7 @@ jobs:
       - run: |
           docker build -t ${action_name} ./${action_name}
           docker run ${action_name} \
+            --env GITHUB_OUTPUT=/dev/null \
             --github-repository ${{ github.repository }} \
             --github-ref ${{ github.ref }} \
             --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/require-semver-guidance-label/require_semver_guidance_label.py
+++ b/require-semver-guidance-label/require_semver_guidance_label.py
@@ -28,10 +28,6 @@ def get_pr_number(github_ref: str) -> int:
         )
 
 
-def set_ci_output(key: str, val: Any):
-    print(f'"{key}={val}" >> $GITHUB_OUTPUT')
-
-
 if __name__ == "__main__":
     args = get_parser().parse_args()
     repo = Github(args.github_token).get_repo(args.github_repository)
@@ -57,5 +53,7 @@ if __name__ == "__main__":
             "version string."
         )
 
-    set_ci_output('pr-number', pr_number)
-    set_ci_output('guidance', guidance[0])
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    with open(output_file, "a") as outf:
+        print(f"pr-number={pr_number}", file=outf)
+        print(f"guidance={guidance[0]}", file=outf)

--- a/require-semver-guidance-label/require_semver_guidance_label.py
+++ b/require-semver-guidance-label/require_semver_guidance_label.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import re
-from typing import Any
 
 from github import Github
 from argparse import ArgumentParser
@@ -54,6 +53,7 @@ if __name__ == "__main__":
         )
 
     output_file = os.environ.get("GITHUB_OUTPUT")
-    with open(output_file, "a") as outf:
-        print(f"pr-number={pr_number}", file=outf)
-        print(f"guidance={guidance[0]}", file=outf)
+    if output_file:
+        with open(output_file, "a") as outf:
+            print(f"pr-number={pr_number}", file=outf)
+            print(f"guidance={guidance[0]}", file=outf)

--- a/require-semver-guidance-label/require_semver_guidance_label.py
+++ b/require-semver-guidance-label/require_semver_guidance_label.py
@@ -53,7 +53,6 @@ if __name__ == "__main__":
         )
 
     output_file = os.environ.get("GITHUB_OUTPUT")
-    if output_file:
-        with open(output_file, "a") as outf:
-            print(f"pr-number={pr_number}", file=outf)
-            print(f"guidance={guidance[0]}", file=outf)
+    with open(output_file, "a") as outf:
+        print(f"pr-number={pr_number}", file=outf)
+        print(f"guidance={guidance[0]}", file=outf)


### PR DESCRIPTION
A literacy failure in #26 led it to create a bug - the output was printed but not actually recorded in the github output

![image](https://github.com/UWIT-IAM/actions/assets/26555712/48a75fd3-9ffd-4e8a-b583-fc32e0ee1c42)

🤦

This fixes the bug  

![image](https://github.com/UWIT-IAM/actions/assets/26555712/9fb514e3-8846-4fd2-908b-2534609b59c0)

Somewhat interesting is the [required input in the action this fed into](https://github.com/UWIT-IAM/actions/blob/main/update-pr-branch-version-python/action.yml#L4-L6) didn't yield any error when it wasn't provided.