### PR TITLE
[GH-45] update the configure-gcloud-docker-gcloud-v101 action to use google-github-actions/auth@v2

### DIFF
--- a/configure-gcloud-docker-gcloud-v101/action.yml
+++ b/configure-gcloud-docker-gcloud-v101/action.yml
@@ -24,7 +24,9 @@ runs:
       uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: ${{ inputs.gcloud-token }}
-    - uses: google-github-actions/setup-gcloud@v1.0.1
+    - id: 'setup-gcloud'  # New step with your chosen ID
+      name: 'Run setup-gcloud'
+      uses: google-github-actions/setup-gcloud@v1.0.1
       # prior releases of this action used the below "with" block.
       # Leaving the block in tact but commented out as it might be useful for reference
       # with:

--- a/configure-gcloud-docker-gcloud-v101/action.yml
+++ b/configure-gcloud-docker-gcloud-v101/action.yml
@@ -19,7 +19,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: google-github-actions/auth@v0
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: ${{ inputs.gcloud-token }}
     - uses: google-github-actions/setup-gcloud@v1.0.1


### PR DESCRIPTION
This update is to bring in a supported version of google-github-actions/auth, version 2.
[GH-45](https://github.com/UWIT-IAM/uw-idp-web-tests/issues/45) was created in the [uw-idp-web-tests](https://github.com/UWIT-IAM/uw-idp-web-tests) 
Closes [GH-45](https://github.com/UWIT-IAM/uw-idp-web-tests/issues/45)