### PR TITLE
Replace 3rd party poetry installer with pipx install, 3rd party is broken, cascading to identity builds.

### DIFF
--- a/update-pr-branch-version/action.yml
+++ b/update-pr-branch-version/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Python Poetry Action
-      uses: abatilo/actions-poetry@v2.1.6
+      run: pipx install poetry==1.1.15
 
     - uses: actions/checkout@v2
       with:

--- a/update-pr-branch-version/action.yml
+++ b/update-pr-branch-version/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Python Poetry Action
       run: pipx install poetry==1.1.15
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         # Checks out the branch that PR wants to merge into,
         # (i.e., the default branch).
@@ -36,7 +36,7 @@ runs:
       id: get-version
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       # Checks out the PR branch to update the version based
       # on the default branch version.
       with:


### PR DESCRIPTION
1. the action https://github.com/abatilo/actions-poetry/ does not properly install poetry anymore
2. we should get off this dependency
3. I pinned the poetry version to the one the  3rd party was installing for us.
4. Updated the `checkout` since we're touching this file.

https://python-poetry.org/docs/#ci-recommendations

Glen will sync with @miker985 after this update to chat about other existing actions that might be more robust.