### PR TITLE
[GH-787] update the version used for google-github-actions/auth from v0 to v2

### DIFF
--- a/finalize-slack-notification-canvas/action.yml
+++ b/finalize-slack-notification-canvas/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: google-github-actions/auth@v0
+    - uses: google-github-actions/auth@v2
       with:
         credentials_json: "${{ inputs.gcloud-token || env.GCLOUD_TOKEN }}"
     - uses: google-github-actions/setup-gcloud@v1.0.1

--- a/set-up-slack-notification-canvas/action.yml
+++ b/set-up-slack-notification-canvas/action.yml
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: google-github-actions/auth@v0
+    - uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ inputs.gcloud-token || env.GCLOUD_TOKEN }}"
     - uses: google-github-actions/setup-gcloud@v1.0.1


### PR DESCRIPTION
The [identity-uw repo](https://github.com/UWIT-IAM/identity-uw/issues/787) makes use of scripts in this `actions` repo. When we deploy identity, we get a few warnings about `auth@v0`. This should bring us up to date. v2 is currently being used in other areas and is proven.